### PR TITLE
Correct `name` field to `scheme`

### DIFF
--- a/tokyonight.yaml
+++ b/tokyonight.yaml
@@ -1,4 +1,4 @@
-name: "Tokyonight"
+scheme: "Tokyonight"
 author: "Folke Lemaitre (https://github.com/folke)"
 base00: "24283b"
 base01: "1f2335"


### PR DESCRIPTION
Hey!
This scheme currently fails to be parsed because the [`name` field is actually supposed to be named `scheme`](https://github.com/chriskempson/base16/blob/master/file.md#scheme-files). Here's a fix!